### PR TITLE
Add support for dialogs

### DIFF
--- a/examples/Dialog.hs
+++ b/examples/Dialog.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE OverloadedLabels  #-}
 {-# LANGUAGE OverloadedLists   #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -12,9 +13,9 @@ import           Control.Monad                 (void)
 import           Data.Maybe
 
 import           Data.Text                     (Text)
-import           GI.Gtk                        (Box (..), Button (..),
-                                                Dialog (..), Label (..),
-                                                Orientation (..))
+import           GI.Gtk                        (Align (..), Box (..),
+                                                Button (..), Dialog (..),
+                                                Label (..), Orientation (..))
 import           GI.Gtk.Declarative
 import           GI.Gtk.Declarative.App.Simple
 
@@ -31,13 +32,23 @@ view' (State msg) =
              ] $
     container Box [#orientation := OrientationVertical]
     [ BoxChild defaultBoxChildProperties { expand = True, fill = True } msgLabel
-    , container Box []
+    , paddedAround 5 $
+      container Box [#halign := AlignEnd, #spacing := 5]
       [ widget Button [#label := "Cancel", on #clicked Cancelled]
       , widget Button [#label := "OK", on #clicked Confirmed]
       ]
     ]
   where
     msgLabel = widget Label [#label := fromMaybe "Nothing here yet." msg]
+    -- | Wrap a widget in two boxes (vertical and horizontal) to pad
+    -- it evenly.
+    paddedAround spacing =
+      container Box [#orientation := OrientationVertical]
+      . pure
+      . BoxChild defaultBoxChildProperties { padding = spacing, expand = True, fill = True }
+      . container Box []
+      . pure
+      . BoxChild defaultBoxChildProperties { padding = spacing, expand = True, fill = True }
 
 update' :: State -> Event -> Transition State Event
 update' _ Confirmed = Transition (State (Just "Confirmed.")) (pure Nothing)

--- a/examples/Dialog.hs
+++ b/examples/Dialog.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE OverloadedLabels  #-}
+{-# LANGUAGE OverloadedLists   #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Example of using the 'Dialog' widget. Note that it's not using
+-- the action bar support, nor the response codes mechanism of GTK+
+-- dialogs. Those are more object-oriented APIs that do not fit well
+-- with gi-gtk-declarative.
+module Dialog where
+
+import           Control.Monad                 (void)
+
+import           GI.Gtk                        (Dialog (..), Label (..))
+import           GI.Gtk.Declarative
+import           GI.Gtk.Declarative.App.Simple
+
+data State = Initial
+
+data Event = Confirmed | Cancelled | Closed
+
+view' :: State -> AppView Dialog Event
+view' Initial =
+  bin Dialog [#title := "Hello", on #deleteEvent (const (True, Closed))] $
+    widget Label [#label := "Nothing here yet."]
+
+update' :: State -> Event -> Transition State Event
+update' _ Confirmed = Exit
+update' _ Cancelled = Exit
+update' _ Closed    = Exit
+
+main :: IO ()
+main = void $ run App
+  { view         = view'
+  , update       = update'
+  , inputs       = []
+  , initialState = Initial
+  }
+

--- a/examples/Main.hs
+++ b/examples/Main.hs
@@ -7,6 +7,7 @@ import           System.IO
 import qualified AddBoxes
 import qualified CSS
 import qualified CustomWidget
+import qualified Dialog
 import qualified Exit
 import qualified FileChooserButton
 import qualified Functor
@@ -29,6 +30,7 @@ main =
                  , ("MenuBar", MenuBar.main)
                  , ("CSS", CSS.main)
                  , ("Paned", Paned.main)
+                 , ("Dialog", Dialog.main)
                  ]
   in getArgs >>= \case
     [example] ->

--- a/examples/examples.cabal
+++ b/examples/examples.cabal
@@ -20,6 +20,7 @@ executable example
   other-modules:        AddBoxes
                       , CSS
                       , CustomWidget
+                      , Dialog
                       , Exit
                       , FileChooserButton
                       , Functor

--- a/gi-gtk-declarative-app-simple/src/GI/Gtk/Declarative/App/Simple.hs
+++ b/gi-gtk-declarative-app-simple/src/GI/Gtk/Declarative/App/Simple.hs
@@ -95,7 +95,10 @@ run app = do
 --       Gtk.mainQuit
 --     Gtk.main
 -- @
-runLoop :: (Typeable event, Gtk.IsWindow window, Gtk.IsBin window) => App window state event -> IO state
+runLoop
+  :: (Typeable event, Gtk.IsWindow window, Gtk.IsBin window)
+  => App window state event
+  -> IO state
 runLoop App {..} = do
   let firstMarkup = view initialState
   events                  <- newChan

--- a/gi-gtk-declarative/src/GI/Gtk/Declarative/Bin.hs
+++ b/gi-gtk-declarative/src/GI/Gtk/Declarative/Bin.hs
@@ -82,11 +82,8 @@ instance (Gtk.IsBin parent) => Patchable (Bin parent) where
 
     childState <- create child
     childWidget <- someStateWidget childState
-    Gtk.castTo Gtk.Dialog widget' >>= \case
-      Just dialog -> do
-        content <- Gtk.dialogGetContentArea dialog
-        Gtk.containerAdd content childWidget
-      Nothing   -> Gtk.containerAdd widget' childWidget
+    maybe (pure ()) Gtk.widgetDestroy =<< Gtk.binGetChild widget'
+    Gtk.containerAdd widget' childWidget
     return (SomeState (StateTreeBin (StateTreeNode widget' sc collected ()) childState))
 
   patch (SomeState (st :: StateTree stateType w1 c1 e1 cs))
@@ -109,11 +106,8 @@ instance (Gtk.IsBin parent) => Patchable (Bin parent) where
               newChildState <- createNew
               childWidget <- someStateWidget newChildState
               Gtk.widgetShow childWidget
-              Gtk.castTo Gtk.Dialog binWidget >>= \case
-                Just dialog -> do
-                  content <- Gtk.dialogGetContentArea dialog
-                  Gtk.containerAdd content childWidget
-                Nothing   -> Gtk.containerAdd binWidget childWidget
+              maybe (pure ()) Gtk.widgetDestroy =<< Gtk.binGetChild binWidget
+              Gtk.containerAdd binWidget childWidget
               return (SomeState (StateTreeBin top' newChildState))
             Keep -> return (SomeState st)
       _ -> Replace (create (Bin ctor newAttributes newChild))

--- a/gi-gtk-declarative/src/GI/Gtk/Declarative/Container.hs
+++ b/gi-gtk-declarative/src/GI/Gtk/Declarative/Container.hs
@@ -1,7 +1,5 @@
 {-# OPTIONS_GHC -fno-warn-unticked-promoted-constructors #-}
 {-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE DefaultSignatures     #-}
-{-# LANGUAGE DeriveFunctor         #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE GADTs                 #-}

--- a/gi-gtk-declarative/src/GI/Gtk/Declarative/Container/Box.hs
+++ b/gi-gtk-declarative/src/GI/Gtk/Declarative/Container/Box.hs
@@ -1,10 +1,11 @@
-{-# OPTIONS_GHC -fno-warn-unticked-promoted-constructors -fno-warn-orphans #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE DeriveFunctor         #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE GADTs                 #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns        #-}
 {-# LANGUAGE OverloadedLabels      #-}
 {-# LANGUAGE RecordWildCards       #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
@@ -56,3 +57,11 @@ instance EventSource BoxChild where
   subscribe BoxChild{..} = subscribe child
 
 instance ToChildren Gtk.Box Vector BoxChild
+
+instance IsContainer Gtk.Box BoxChild where
+  appendChild box BoxChild {properties = BoxChildProperties {expand, fill, padding}} widget' =
+    Gtk.boxPackStart box widget' expand fill padding
+  replaceChild box boxChild' i old new = do
+    Gtk.widgetDestroy old
+    appendChild box boxChild' new
+    Gtk.boxReorderChild box new i

--- a/gi-gtk-declarative/src/GI/Gtk/Declarative/Container/ListBox.hs
+++ b/gi-gtk-declarative/src/GI/Gtk/Declarative/Container/ListBox.hs
@@ -11,4 +11,11 @@ import qualified GI.Gtk                             as Gtk
 import           GI.Gtk.Declarative.Bin
 import           GI.Gtk.Declarative.Container.Class
 
+instance IsContainer Gtk.ListBox (Bin Gtk.ListBoxRow) where
+  appendChild box _ widget' =
+    Gtk.listBoxInsert box widget' (-1)
+  replaceChild box _ i old new = do
+    Gtk.widgetDestroy old
+    Gtk.listBoxInsert box new i
+
 instance ToChildren Gtk.ListBox Vector (Bin Gtk.ListBoxRow)

--- a/gi-gtk-declarative/src/GI/Gtk/Declarative/Container/Patch.hs
+++ b/gi-gtk-declarative/src/GI/Gtk/Declarative/Container/Patch.hs
@@ -1,4 +1,4 @@
-{-# OPTIONS_GHC -fno-warn-unticked-promoted-constructors -fno-warn-orphans #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE FlexibleContexts      #-}
@@ -9,7 +9,6 @@
 {-# LANGUAGE NamedFieldPuns        #-}
 {-# LANGUAGE OverloadedLabels      #-}
 {-# LANGUAGE OverloadedLists       #-}
-{-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE TypeOperators         #-}
@@ -26,8 +25,6 @@ import           Data.Vector                        (Vector, (!?))
 import qualified Data.Vector                        as Vector
 import qualified GI.Gtk                             as Gtk
 
-import           GI.Gtk.Declarative.Bin
-import           GI.Gtk.Declarative.Container.Box
 import           GI.Gtk.Declarative.Container.Class
 import           GI.Gtk.Declarative.Patch
 import           GI.Gtk.Declarative.State
@@ -114,18 +111,3 @@ patchInContainer (StateTreeContainer top children) container os' ns' = do
 
 padMaybes :: Int -> Vector a -> Vector (Maybe a)
 padMaybes len xs = Vector.generate len (xs !?)
-
-instance IsContainer Gtk.ListBox (Bin Gtk.ListBoxRow) where
-  appendChild box _ widget' =
-    Gtk.listBoxInsert box widget' (-1)
-  replaceChild box _ i old new = do
-    Gtk.widgetDestroy old
-    Gtk.listBoxInsert box new i
-
-instance IsContainer Gtk.Box BoxChild where
-  appendChild box BoxChild {properties = BoxChildProperties {expand, fill, padding}} widget' =
-    Gtk.boxPackStart box widget' expand fill padding
-  replaceChild box boxChild' i old new = do
-    Gtk.widgetDestroy old
-    appendChild box boxChild' new
-    Gtk.boxReorderChild box new i

--- a/gi-gtk-declarative/src/GI/Gtk/Declarative/Widget.hs
+++ b/gi-gtk-declarative/src/GI/Gtk/Declarative/Widget.hs
@@ -55,8 +55,13 @@ instance EventSource Widget where
 -- some specifically typed widget, depending on the context in which it's
 -- used.
 class FromWidget widget target where
-  fromWidget :: (Typeable widget, Typeable event) => widget event -> target event
+  fromWidget :: widget event -> target event
 
-instance (Patchable (parent child), Functor (parent child), EventSource (parent child))
+instance ( Typeable parent
+         , Typeable child
+         , Patchable (parent child)
+         , Functor (parent child)
+         , EventSource (parent child)
+         )
          => FromWidget (parent child) Widget where
   fromWidget = Widget


### PR DESCRIPTION
This adds a special case for dialogs, where the direct bin child can't be patched, but rather the one within the content area.