### PR TITLE
Bump upper bound on haskell-gi

### DIFF
--- a/examples/CustomWidget.hs
+++ b/examples/CustomWidget.hs
@@ -63,6 +63,7 @@ numberInput customData = Widget
   -- A function that computes a patch for our custom widget. Here we
   -- compare the NumberInputProperties value to decide whether to
   -- modify the widget.
+  customPatch :: SomeState -> NumberInputProperties -> NumberInputProperties -> CustomPatch Gtk.SpinButton customData
   customPatch (SomeState st) old new
     | old == new = CustomKeep
     | otherwise = CustomModify $ \(spin :: Gtk.SpinButton) -> do

--- a/gi-gtk-declarative-app-simple/gi-gtk-declarative-app-simple.cabal
+++ b/gi-gtk-declarative-app-simple/gi-gtk-declarative-app-simple.cabal
@@ -1,5 +1,5 @@
 name:                 gi-gtk-declarative-app-simple
-version:              0.4.1
+version:              0.4.2
 synopsis:             Declarative GTK+ programming in Haskell in the style of Pux.
 description:          Experimental application architecture in the style of
                       PureScript Pux, built on top of gi-gtk-declarative.
@@ -27,8 +27,8 @@ library
                       , gi-glib
                       , gi-gtk                  >= 3      && <4
                       , gi-gdk
-                      , haskell-gi              >= 0.21   && <0.22
-                      , haskell-gi-base         >= 0.21   && <0.22
+                      , haskell-gi              >= 0.21   && <0.23
+                      , haskell-gi-base         >= 0.21   && <0.23
                       , haskell-gi-overloading  == 1.0
                       , pipes                   >= 4      && <5
                       , pipes-concurrency       >= 2      && <3

--- a/gi-gtk-declarative/gi-gtk-declarative.cabal
+++ b/gi-gtk-declarative/gi-gtk-declarative.cabal
@@ -1,5 +1,5 @@
 name:                 gi-gtk-declarative
-version:              0.4.2
+version:              0.4.3
 synopsis:             Declarative GTK+ programming in Haskell
 description:          A declarative programming model for GTK+ user
                       interfaces, implementing support for various widgets
@@ -54,8 +54,8 @@ library
                       , gi-gobject             >= 2    && <3
                       , gi-glib                >= 2    && <3
                       , gi-gtk                 >= 3    && <4
-                      , haskell-gi             >= 0.21 && <0.22
-                      , haskell-gi-base        >= 0.21 && <0.22
+                      , haskell-gi             >= 0.21 && <0.23
+                      , haskell-gi-base        >= 0.21 && <0.23
                       , haskell-gi-overloading == 1.0
                       , mtl
                       , text


### PR DESCRIPTION
Hi @owickstrom,

thanks for the great library. I had trouble compiling `gi-gio-2.0.22` on macOS (likely related to haskell-gi/haskell-gi#218 although I get a different error), so I tried to bump up the upper bound on `haskell-gi` and everything seems to work fine, with perhaps the only exception of a type annotation I had to put on `examples/CustomWidget.hs`. The this bumps the minor release, I am not sure if you want to do it differently.

my 2c,
cheers