### PR TITLE
Remove afterCreated attribute

### DIFF
--- a/gi-gtk-declarative/src/GI/Gtk/Declarative/Attributes.hs
+++ b/gi-gtk-declarative/src/GI/Gtk/Declarative/Attributes.hs
@@ -16,7 +16,6 @@
 module GI.Gtk.Declarative.Attributes
   ( Attribute(..)
   , classes
-  , afterCreated
   , ClassSet
   -- * Event Handling
   , on
@@ -89,10 +88,6 @@ data Attribute widget event where
     => Gtk.SignalProxy widget info
     -> EventHandler gtkCallback widget Impure event
     -> Attribute widget event
-  -- | Provide a callback to modify the widget after it's been created.
-  AfterCreated
-    :: (widget -> IO ())
-    -> Attribute widget event
 
 -- | A set of CSS classes.
 type ClassSet = HashSet Text
@@ -105,7 +100,6 @@ instance Functor (Attribute widget) where
     Classes cs -> Classes cs
     OnSignalPure signal eh -> OnSignalPure signal (fmap f eh)
     OnSignalImpure signal eh -> OnSignalImpure signal (fmap f eh)
-    AfterCreated eh -> AfterCreated eh
 
 -- | Define the CSS classes for the underlying widget's style context. For these
 -- classes to have any effect, this requires a 'Gtk.CssProvider' with CSS files
@@ -143,7 +137,3 @@ onM
   -> userEventHandler
   -> Attribute widget event
 onM signal = OnSignalImpure signal . toEventHandler
-
--- | Provide a EventHandler to modify the widget after it's been created.
-afterCreated :: (widget -> IO ()) -> Attribute widget event
-afterCreated = AfterCreated

--- a/gi-gtk-declarative/src/GI/Gtk/Declarative/Attributes/Internal.hs
+++ b/gi-gtk-declarative/src/GI/Gtk/Declarative/Attributes/Internal.hs
@@ -6,8 +6,7 @@
 -- | Internal helpers for applying attributes and signal handlers to GTK+
 -- widgets.
 module GI.Gtk.Declarative.Attributes.Internal
-  ( applyAfterCreated
-  , addSignalHandler
+  ( addSignalHandler
   )
 where
 
@@ -19,11 +18,6 @@ import qualified GI.Gtk                        as Gtk
 import           GI.Gtk.Declarative.Attributes
 import           GI.Gtk.Declarative.Attributes.Internal.Conversions
 import           GI.Gtk.Declarative.EventSource
-
-applyAfterCreated :: widget -> Attribute widget event -> IO ()
-applyAfterCreated widget = \case
-  (AfterCreated f) -> f widget
-  _                -> return ()
 
 addSignalHandler
   :: (Gtk.IsWidget widget, MonadIO m)

--- a/gi-gtk-declarative/src/GI/Gtk/Declarative/Bin.hs
+++ b/gi-gtk-declarative/src/GI/Gtk/Declarative/Bin.hs
@@ -75,8 +75,6 @@ instance (Gtk.IsBin parent) => Patchable (Bin parent) where
     sc <- Gtk.widgetGetStyleContext widget'
     updateClasses sc mempty (collectedClasses collected)
 
-    mapM_ (applyAfterCreated widget') attrs
-
     childState <- create child
     childWidget <- someStateWidget childState
     maybe (pure ()) Gtk.widgetDestroy =<< Gtk.binGetChild widget'

--- a/gi-gtk-declarative/src/GI/Gtk/Declarative/Container.hs
+++ b/gi-gtk-declarative/src/GI/Gtk/Declarative/Container.hs
@@ -84,7 +84,6 @@ instance (Patchable child, Typeable child, IsContainer container child) =>
     Gtk.widgetShow widget'
     sc <- Gtk.widgetGetStyleContext widget'
     updateClasses sc mempty (collectedClasses collected)
-    mapM_ (applyAfterCreated widget') attrs
     childStates <-
       forM (unChildren children) $ \child -> do
         childState <- create child

--- a/gi-gtk-declarative/src/GI/Gtk/Declarative/SingleWidget.hs
+++ b/gi-gtk-declarative/src/GI/Gtk/Declarative/SingleWidget.hs
@@ -48,8 +48,6 @@ instance Patchable (SingleWidget widget) where
         Gtk.widgetShow widget'
         sc <- Gtk.widgetGetStyleContext widget'
         updateClasses sc mempty (collectedClasses collected)
-        mapM_ (applyAfterCreated widget') attrs
-
         return (SomeState (StateTreeWidget (StateTreeNode widget' sc collected ())))
   patch (SomeState (st :: StateTree stateType w child event cs))
         (SingleWidget (_    :: Gtk.ManagedPtr w1 -> w1) _)


### PR DESCRIPTION
This removes the `afterCreated` attribute. If you have need for interacting with the underlying GTK widget in a special way, implement a `CustomWidget`. 

Closes #13 