### PR TITLE
Property tests for patching

### DIFF
--- a/ghcid-test.sh
+++ b/ghcid-test.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 
+export HEDGEHOG_COLOR=1
+
 ghcid \
   -c 'ghci -igi-gtk-declarative/src -igi-gtk-declarative/test' \
   --test ':main' \
   --color=always \
   --reload=gi-gtk-declarative \
+  --restart=gi-gtk-declarative/test \
   Main
 
 

--- a/gi-gtk-declarative/gi-gtk-declarative.cabal
+++ b/gi-gtk-declarative/gi-gtk-declarative.cabal
@@ -73,12 +73,14 @@ test-suite gi-gtk-declarative-tests
   main-is:           Main.hs
   build-depends:     base                 >= 4        && < 5
                    , async
+                   , containers
                    , gi-glib
                    , gi-gdk
                    , gi-gobject
                    , gi-gtk
                    , gi-gtk-declarative
                    , hedgehog >= 1 && < 2
+                   , mtl
                    , safe-exceptions
                    , stm
                    , text
@@ -87,3 +89,5 @@ test-suite gi-gtk-declarative-tests
   ghc-options:       -Wall -O2 -rtsopts -with-rtsopts=-N -threaded
   default-language:  Haskell2010
   other-modules:     GI.Gtk.Declarative.CustomWidgetTest
+                   , GI.Gtk.Declarative.PatchTest
+                   , GI.Gtk.Declarative.TestUtils

--- a/gi-gtk-declarative/gi-gtk-declarative.cabal
+++ b/gi-gtk-declarative/gi-gtk-declarative.cabal
@@ -91,3 +91,4 @@ test-suite gi-gtk-declarative-tests
   other-modules:     GI.Gtk.Declarative.CustomWidgetTest
                    , GI.Gtk.Declarative.PatchTest
                    , GI.Gtk.Declarative.TestUtils
+                   , GI.Gtk.Declarative.TestWidget

--- a/gi-gtk-declarative/test/GI/Gtk/Declarative/CustomWidgetTest.hs
+++ b/gi-gtk-declarative/test/GI/Gtk/Declarative/CustomWidgetTest.hs
@@ -31,6 +31,8 @@ import           GI.Gtk.Declarative
 import           GI.Gtk.Declarative.EventSource
 import           GI.Gtk.Declarative.State
 
+import           GI.Gtk.Declarative.TestUtils
+
 prop_sets_the_button_label = property $ do
   start       <- forAll (Gen.int (Range.linear 0 10))
   clicks      <- forAll (Gen.int (Range.linear 0 10))
@@ -126,18 +128,6 @@ testWidget customAttributes customParams = Widget (CustomWidget { .. })
       cb current
       Gtk.set btn [#label Gtk.:= Text.pack (show current)]
     return (fromCancellation (GI.signalHandlerDisconnect btn h))
-
-runUI ma = do
-  ret <- liftIO newEmptyMVar
-  _ <- Gdk.threadsAddIdle GLib.PRIORITY_DEFAULT $ do
-    ma >>= putMVar ret
-    return False
-  liftIO (takeMVar ret)
-
-patch' state markup1 markup2 = case patch state markup1 markup2 of
-  Keep      -> pure state
-  Modify  f -> f
-  Replace f -> f
 
 -- * Test collection
 

--- a/gi-gtk-declarative/test/GI/Gtk/Declarative/Gen.hs
+++ b/gi-gtk-declarative/test/GI/Gtk/Declarative/Gen.hs
@@ -1,0 +1,93 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ViewPatterns #-}
+
+module GI.Gtk.Declarative.Gen where
+
+import Control.Monad.Except
+import Control.Monad.IO.Class
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Data.Vector (Vector)
+import qualified Data.Vector as Vector
+import Data.Void
+import qualified GI.Gtk as Gtk
+import GI.Gtk.Declarative hiding (widget)
+import qualified GI.Gtk.Declarative as Gtk (widget)
+import GI.Gtk.Declarative.EventSource
+import GI.Gtk.Declarative.State
+import Hedgehog hiding (label)
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+import Prelude
+
+data TestWidget
+  = TestButton Text
+  | TestLabel Text
+  | TestBox Gtk.Orientation [TestWidget]
+  deriving (Eq, Show)
+
+toWidget :: TestWidget -> Widget Void
+toWidget = \case
+  TestLabel label -> Gtk.widget Gtk.Label [#label := label]
+  TestButton label -> Gtk.widget Gtk.Button [#label := label]
+  TestBox orientation children ->
+    container
+      Gtk.Box
+      [#orientation := orientation]
+      (Vector.map (BoxChild defaultBoxChildProperties . toWidget) (Vector.fromList children))
+
+fromGtkWidget :: (MonadIO m) => Gtk.Widget -> m (Either Text TestWidget)
+fromGtkWidget = runExceptT . go
+  where
+    go :: (MonadIO m) => Gtk.Widget -> ExceptT Text m TestWidget
+    go w = do
+      name <- #getName w
+      case name of
+        "GtkButton" -> withCast w Gtk.Button (\btn -> TestButton <$> Gtk.get btn #label)
+        "GtkLabel" -> withCast w Gtk.Label (\lbl -> TestLabel <$> Gtk.get lbl #label)
+        "GtkBox" -> withCast w Gtk.Box $ \box -> do
+          childWidgets <- traverse go =<< #getChildren box
+          orientation <- Gtk.get box #orientation
+          pure (TestBox orientation childWidgets)
+        _ -> throwError ("Unsupported TestWidget: " <> name)
+    withCast ::
+      (MonadIO m, Gtk.GObject w, Gtk.GObject w') =>
+      w ->
+      (Gtk.ManagedPtr w' -> w') ->
+      (w' -> ExceptT Text m a) ->
+      ExceptT Text m a
+    withCast w ctor f = liftIO (Gtk.castTo ctor w) >>= \case
+      Just w' -> f w'
+      Nothing -> throwError "Failed to cast widget"
+
+widget :: Gen TestWidget
+widget =
+  Gen.recursive
+    Gen.choice
+    [ label,
+      button
+    ]
+    (subwidgets (\ws -> (\o -> TestBox o ws) <$> genOrientation))
+  where
+    -- In lack of `subtermN` (https://github.com/hedgehogqa/haskell-hedgehog/issues/119), we use this terrible hack:
+    subwidgets :: ([TestWidget] -> Gen TestWidget) -> [Gen TestWidget]
+    subwidgets f =
+      [ f [],
+        Gen.subtermM widget (\w -> f [w]),
+        Gen.subtermM2 widget widget (\w1 w2 -> f [w1, w2]),
+        Gen.subtermM3 widget widget widget (\w1 w2 w3 -> f [w1, w2, w3])
+      ]
+
+genOrientation :: Gen Gtk.Orientation
+genOrientation = Gen.choice [pure Gtk.OrientationVertical, pure Gtk.OrientationHorizontal]
+
+label :: Gen TestWidget
+label = do
+  TestLabel <$> Gen.text (Range.linear 0 10) Gen.unicode
+
+button :: Gen TestWidget
+button = do
+  TestButton <$> Gen.text (Range.linear 0 10) Gen.unicode

--- a/gi-gtk-declarative/test/GI/Gtk/Declarative/PatchTest.hs
+++ b/gi-gtk-declarative/test/GI/Gtk/Declarative/PatchTest.hs
@@ -29,7 +29,7 @@ import qualified GI.Gdk as Gdk
 import qualified GI.Gtk as Gtk
 import GI.Gtk.Declarative
 import GI.Gtk.Declarative.EventSource
-import qualified GI.Gtk.Declarative.Gen as Gen
+import GI.Gtk.Declarative.TestWidget
 import GI.Gtk.Declarative.State
 import GI.Gtk.Declarative.TestUtils
 import Hedgehog
@@ -37,9 +37,9 @@ import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
 prop_history_of_prior_patches_has_no_effect_on_resulting_widget = property $ do
-  (first : intermediate) <- forAll (Gen.list (Range.linear 1 100) Gen.widget)
-  last <- forAll Gen.widget
-  cover 10 "nested widgets" (case last of Gen.TestBox _ (_:_) -> True; _ -> False)
+  (first : intermediate) <- forAll (Gen.list (Range.linear 1 100) genTestWidget)
+  last <- forAll genTestWidget
+  cover 10 "nested widgets" (case last of TestBox _ (_:_) -> True; _ -> False)
   -- Directly creating the 'last' widget.
   widget <- assertRight =<< patchAllInNewWindow last []
   -- Creating and patching all prior widgets before patching with the 'last' widget.
@@ -54,14 +54,14 @@ assertRight (Right a) = pure a
 patchAll :: SomeState -> Widget event -> [Widget event] -> IO SomeState
 patchAll s1 w ws = fst <$> foldM (\(s, w1) w2 -> (,w2) <$> patch' s w1 w2) (s1, w) ws
 
-patchAllInNewWindow :: MonadIO m => Gen.TestWidget -> [Gen.TestWidget] -> m (Either Text Gen.TestWidget)
+patchAllInNewWindow :: MonadIO m => TestWidget -> [TestWidget] -> m (Either Text TestWidget)
 patchAllInNewWindow first rest = runUI . bracket (Gtk.new Gtk.Window []) #destroy $ \window -> do
-  firstState <- create (Gen.toWidget first)
+  firstState <- create (toTestWidget first)
   widget <- liftIO (someStateWidget firstState)
   #add window widget
   Gtk.widgetShowAll window
-  lastState <- patchAll firstState (Gen.toWidget first) (map Gen.toWidget rest)
-  Gen.fromGtkWidget =<< someStateWidget lastState
+  lastState <- patchAll firstState (toTestWidget first) (map toTestWidget rest)
+  fromGtkWidget =<< someStateWidget lastState
 
 -- * Test collection
 

--- a/gi-gtk-declarative/test/GI/Gtk/Declarative/PatchTest.hs
+++ b/gi-gtk-declarative/test/GI/Gtk/Declarative/PatchTest.hs
@@ -39,7 +39,8 @@ import qualified Hedgehog.Range as Range
 prop_history_of_prior_patches_has_no_effect_on_resulting_widget = property $ do
   (first : intermediate) <- forAll (Gen.list (Range.linear 1 100) genTestWidget)
   last <- forAll genTestWidget
-  cover 10 "nested widgets" (case last of TestBox _ (_:_) -> True; _ -> False)
+  cover 10 "prior include nested widgets" (any isNested (first : intermediate))
+  cover 10 "last is nested widget" (isNested last)
   -- Directly creating the 'last' widget.
   widget <- assertRight =<< patchAllInNewWindow last []
   -- Creating and patching all prior widgets before patching with the 'last' widget.

--- a/gi-gtk-declarative/test/GI/Gtk/Declarative/PatchTest.hs
+++ b/gi-gtk-declarative/test/GI/Gtk/Declarative/PatchTest.hs
@@ -1,0 +1,70 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TupleSections #-}
+{-# OPTIONS_GHC -fno-warn-missing-signatures #-}
+
+module GI.Gtk.Declarative.PatchTest where
+
+import Control.Concurrent
+import Control.Concurrent.STM
+import Control.Exception.Safe
+import Control.Monad (replicateM_)
+import Control.Monad (foldM)
+import Control.Monad.IO.Class
+import Data.Foldable (traverse_)
+import Data.Function ((&))
+import qualified Data.HashSet as HashSet
+import qualified Data.Text as Text
+import Data.Text (Text)
+import Data.Tree
+import Data.Vector (Vector)
+import qualified GI.GLib.Constants as GLib
+import qualified GI.GObject as GI
+import qualified GI.Gdk as Gdk
+import qualified GI.Gtk as Gtk
+import GI.Gtk.Declarative
+import GI.Gtk.Declarative.EventSource
+import qualified GI.Gtk.Declarative.Gen as Gen
+import GI.Gtk.Declarative.State
+import GI.Gtk.Declarative.TestUtils
+import Hedgehog
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+
+prop_history_of_prior_patches_has_no_effect_on_resulting_widget = property $ do
+  (first : intermediate) <- forAll (Gen.list (Range.linear 1 100) Gen.widget)
+  last <- forAll Gen.widget
+  cover 10 "nested widgets" (case last of Gen.TestBox _ (_:_) -> True; _ -> False)
+  -- Directly creating the 'last' widget.
+  widget <- assertRight =<< patchAllInNewWindow last []
+  -- Creating and patching all prior widgets before patching with the 'last' widget.
+  widget' <- assertRight =<< patchAllInNewWindow first (intermediate <> pure last)
+  -- They should be the same.
+  widget === widget'
+
+assertRight :: MonadTest m => Either Text a -> m a
+assertRight (Left err) = annotate (Text.unpack err) >> failure
+assertRight (Right a) = pure a
+
+patchAll :: SomeState -> Widget event -> [Widget event] -> IO SomeState
+patchAll s1 w ws = fst <$> foldM (\(s, w1) w2 -> (,w2) <$> patch' s w1 w2) (s1, w) ws
+
+patchAllInNewWindow :: MonadIO m => Gen.TestWidget -> [Gen.TestWidget] -> m (Either Text Gen.TestWidget)
+patchAllInNewWindow first rest = runUI . bracket (Gtk.new Gtk.Window []) #destroy $ \window -> do
+  firstState <- create (Gen.toWidget first)
+  widget <- liftIO (someStateWidget firstState)
+  #add window widget
+  Gtk.widgetShowAll window
+  lastState <- patchAll firstState (Gen.toWidget first) (map Gen.toWidget rest)
+  Gen.fromGtkWidget =<< someStateWidget lastState
+
+-- * Test collection
+
+tests :: IO Bool
+tests =
+  checkParallel $$(discover)

--- a/gi-gtk-declarative/test/GI/Gtk/Declarative/TestUtils.hs
+++ b/gi-gtk-declarative/test/GI/Gtk/Declarative/TestUtils.hs
@@ -1,0 +1,36 @@
+module GI.Gtk.Declarative.TestUtils where
+
+import Control.Concurrent
+import Control.Concurrent.STM
+import Control.Exception.Safe
+import Control.Monad (replicateM_)
+import Control.Monad.IO.Class
+import Data.Function ((&))
+import qualified Data.HashSet as HashSet
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Data.Vector (Vector)
+import qualified GI.GLib.Constants as GLib
+import qualified GI.GObject as GI
+import qualified GI.Gdk as Gdk
+import qualified GI.Gtk as Gtk
+import GI.Gtk.Declarative
+import GI.Gtk.Declarative.EventSource
+import GI.Gtk.Declarative.State
+import Hedgehog
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+
+runUI :: MonadIO m => IO b -> m b
+runUI ma = do
+  ret <- liftIO newEmptyMVar
+  _ <- Gdk.threadsAddIdle GLib.PRIORITY_DEFAULT $ do
+    ma >>= putMVar ret
+    return False
+  liftIO (takeMVar ret)
+
+patch' :: Patchable widget => SomeState -> widget e1 -> widget e2 -> IO SomeState
+patch' state markup1 markup2 = case patch state markup1 markup2 of
+  Keep -> pure state
+  Modify f -> f
+  Replace f -> f

--- a/gi-gtk-declarative/test/GI/Gtk/Declarative/TestWidget.hs
+++ b/gi-gtk-declarative/test/GI/Gtk/Declarative/TestWidget.hs
@@ -34,6 +34,13 @@ data TestWidget
   | TestBox Gtk.Orientation [TestWidget]
   deriving (Eq, Show)
 
+isNested :: TestWidget -> Bool
+isNested = \case
+  TestButton{} -> False
+  TestLabel{} -> False
+  (TestScrolledWindow _) -> True
+  (TestBox _ children) -> not (null children)
+
 toTestWidget :: TestWidget -> Widget Void
 toTestWidget = \case
   TestLabel label -> Gtk.widget Gtk.Label [#label := label]
@@ -73,6 +80,8 @@ fromGtkWidget = runExceptT . go
     withCast w ctor f = liftIO (Gtk.castTo ctor w) >>= \case
       Just w' -> f w'
       Nothing -> throwError "Failed to cast widget"
+
+-- * Generators
 
 genTestWidget :: Gen TestWidget
 genTestWidget =

--- a/gi-gtk-declarative/test/Main.hs
+++ b/gi-gtk-declarative/test/Main.hs
@@ -7,13 +7,14 @@ import           System.Exit
 import           System.IO
 
 import qualified GI.Gtk.Declarative.CustomWidgetTest as CustomWidget
+import qualified GI.Gtk.Declarative.PatchTest as PatchTest
 
 
 main :: IO ()
 main = do
   _ <- Gtk.init Nothing
   _ <- forkOS $ do
-    results <- sequence [CustomWidget.tests]
+    results <- sequence [CustomWidget.tests, PatchTest.tests]
     Gtk.mainQuit
     unless (and results) $ do
       hPutStrLn stderr "Tests failed."

--- a/hie.yaml
+++ b/hie.yaml
@@ -1,0 +1,6 @@
+cradle:
+  direct:
+    arguments:
+      - -igi-gtk-declarative/src
+      - -igi-gtk-declarative-app-simple/src
+      - -iexamples


### PR DESCRIPTION
This adds a property test that checks that no matter what patches have been previously applied, a successive patch yields the same GTK widget state. Due to GTK widgets not being practically comparable or printable, this test uses an intermediate representation of widgets.