### PR TITLE
Do not ignore exception on main loop

### DIFF
--- a/gi-gtk-declarative-app-simple/default.nix
+++ b/gi-gtk-declarative-app-simple/default.nix
@@ -3,13 +3,15 @@
 }:
 
 let
+  lib = import ../lib.nix { inherit pkgs; };
   haskellPackages = pkgs.haskell.packages.${compiler}.override {
     overrides = self: super: {
       gi-gtk-declarative = gi-gtk-declarative;
     };
   };
   variant = if doBenchmark then pkgs.haskell.lib.doBenchmark else pkgs.lib.id;
-  drv = variant (haskellPackages.callCabal2nix "gi-gtk-declarative-app-simple" ./. {});
+  drv = lib.checkWithGtkDeps
+    (variant (haskellPackages.callCabal2nix "gi-gtk-declarative-app-simple" ./. {}));
 in
 {
   gi-gtk-declarative-app-simple = drv;

--- a/gi-gtk-declarative-app-simple/gi-gtk-declarative-app-simple.cabal
+++ b/gi-gtk-declarative-app-simple/gi-gtk-declarative-app-simple.cabal
@@ -37,3 +37,17 @@ library
   hs-source-dirs:       src
   default-language:     Haskell2010
   ghc-options:          -Wall
+
+test-suite gi-gtk-declarative-app-simple-tests
+  type:             exitcode-stdio-1.0
+  hs-source-dirs:   test
+  main-is:          Main.hs
+  build-depends:    async
+                  , base >= 4 && < 5
+                  , gi-gtk
+                  , gi-gtk-declarative
+                  , gi-gtk-declarative-app-simple
+                  , hspec
+                  , pipes
+  default-language: Haskell2010
+  ghc-options:      -Wall -O2 -rtsopts -with-rtsopts=-N -threaded

--- a/gi-gtk-declarative-app-simple/src/GI/Gtk/Declarative/App/Simple.hs
+++ b/gi-gtk-declarative-app-simple/src/GI/Gtk/Declarative/App/Simple.hs
@@ -196,9 +196,7 @@ runUI_ ma = do
   tId <- myThreadId
 
   void . Gdk.threadsAddIdle GLib.PRIORITY_DEFAULT $ do
-    -- Any exception in the gtk ui thread will be rethrow in the
-    -- calling thread.
+    -- Any exception in the gtk ui thread will be rethrown in the calling thread.
     -- This ensure that this exception won't terminate the application without any control.
-    -- HOWEVER, it may be raised ANYWHERE in the calling thread.
     ma `catch` throwTo @SomeException tId
     return False

--- a/gi-gtk-declarative-app-simple/src/GI/Gtk/Declarative/App/Simple.hs
+++ b/gi-gtk-declarative-app-simple/src/GI/Gtk/Declarative/App/Simple.hs
@@ -18,7 +18,6 @@ import           Control.Concurrent
 import qualified Control.Concurrent.Async      as Async
 import           Control.Exception              ( SomeException,
                                                   Exception,
-                                                  evaluate,
                                                   throwIO,
                                                   catch )
 import           Control.Monad
@@ -147,7 +146,7 @@ runLoop App {..} = do
         a <- Async.async $
           -- TODO: Use prioritized queue for events returned by 'update', to take
           -- precendence over those from 'inputs'.
-          (void $ action >>= maybe (return ()) (writeChan events))
+          action >>= maybe (return ()) (writeChan events)
 
         -- If any exception happen in the action, it will be reraised here and
         -- catched in the thread. See the ExceptionInLinkedThread

--- a/gi-gtk-declarative-app-simple/test/Main.hs
+++ b/gi-gtk-declarative-app-simple/test/Main.hs
@@ -17,6 +17,8 @@ main = hspec $
       runApp app {view = const (error "oh no")} `shouldThrow` errorCall "oh no"
     it "propagates exceptions from update handler itself" $
       runApp app {inputs = [yield ThrowError]} `shouldThrow` errorCall "oh no"
+    it "propagates exceptions from the pipeline itself" $
+      runApp app {inputs = [error "oh no"]} `shouldThrow` errorCall "oh no"
   where
     app = App
       { update = update'

--- a/gi-gtk-declarative-app-simple/test/Main.hs
+++ b/gi-gtk-declarative-app-simple/test/Main.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE OverloadedLists  #-}
+module Main where
+
+import           Control.Monad                 (void)
+import qualified GI.Gtk                        as Gtk
+import           GI.Gtk.Declarative
+import           GI.Gtk.Declarative.App.Simple
+import           Pipes
+import           System.Timeout
+import           Test.Hspec
+
+main :: IO ()
+main = hspec $
+  describe "run" $
+    it "propagates exceptions from update handler itself" $
+      runApp app {inputs = [yield ThrowError]} `shouldThrow` errorCall "oh no"
+  where
+    app = App
+      { update = update'
+      , view = view'
+      , inputs = []
+      , initialState = ()
+      }
+    runApp = timeout 1000000 . void . run
+
+data AppEvent = ThrowError
+
+view' :: () -> AppView Gtk.Window AppEvent
+view' () = bin Gtk.Window [] (widget Gtk.Label [])
+
+update' :: () -> AppEvent -> Transition () AppEvent
+update' () ThrowError = error "oh no"

--- a/gi-gtk-declarative-app-simple/test/Main.hs
+++ b/gi-gtk-declarative-app-simple/test/Main.hs
@@ -12,7 +12,9 @@ import           Test.Hspec
 
 main :: IO ()
 main = hspec $
-  describe "run" $
+  describe "run" $ do
+    it "propagates exceptions from view function" $
+      runApp app {view = const (error "oh no")} `shouldThrow` errorCall "oh no"
     it "propagates exceptions from update handler itself" $
       runApp app {inputs = [yield ThrowError]} `shouldThrow` errorCall "oh no"
   where

--- a/gi-gtk-declarative/default.nix
+++ b/gi-gtk-declarative/default.nix
@@ -3,23 +3,12 @@
 }:
 
 let
+  lib = import ../lib.nix { inherit pkgs; };
   haskellPackages = pkgs.haskell.packages.${compiler};
   applyCheck = if doCheck then pkgs.lib.id else pkgs.haskell.lib.dontCheck;
   applyBench = if doBenchmark then pkgs.haskell.lib.doBenchmark else pkgs.lib.id;
-  drv =
-    pkgs.haskell.lib.addBuildDepends
-      (pkgs.haskell.lib.overrideCabal
-        (applyCheck (applyBench (haskellPackages.callCabal2nix "gi-gtk-declarative" ./. {})))
-        (old: {
-          checkPhase = ''
-            runHook preCheck
-            xvfb-run dbus-run-session \
-              --config-file=${pkgs.dbus.daemon}/share/dbus-1/session.conf \
-              ./Setup test
-            runHook postCheck
-          '';
-        }))
-    (with pkgs; [xvfb_run dbus.daemon]);
+  drv = lib.checkWithGtkDeps
+    (applyCheck (applyBench (haskellPackages.callCabal2nix "gi-gtk-declarative" ./. {})));
 in
 {
   gi-gtk-declarative = drv;

--- a/lib.nix
+++ b/lib.nix
@@ -1,0 +1,16 @@
+{pkgs}:
+
+{
+  checkWithGtkDeps = drv:
+    pkgs.haskell.lib.addBuildDepends
+      (pkgs.haskell.lib.overrideCabal drv (_old: {
+          checkPhase = ''
+            runHook preCheck
+            xvfb-run dbus-run-session \
+                --config-file=${pkgs.dbus.daemon}/share/dbus-1/session.conf \
+                ./Setup test
+            runHook postCheck
+            '';
+      }))
+      (with pkgs; [xvfb_run dbus.daemon]);
+}


### PR DESCRIPTION
This closes #77.

In the previous implementation, any exception in `runLoop` was ignored
until `Gtk.main` ends. This resulted to weird behaviors where user
`update` / `view` functions where ignored, but the application was still
running and primitive gtk events (such as style change on mouse
overlays) were still running, resulting in an apparently alive but
unresponsive application. The exception was also not printed.

With this change, the application now quit if any exception is raised in
the `view` and `update` user function. User are in charge of setting an
exception handler if they want a different behavior.