### PR TITLE
More reproducible and fast nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,7 @@
-{ pkgs ? import <nixpkgs> {}, compiler ? "ghc865", doBenchmark ? false, doCheck ? false }:
+{ pkgs ? import ./nixpkgs.nix, compiler ? "ghc883", doBenchmark ? false, doCheck ? false }:
 rec {
   docs = import ./docs/requirements.nix { inherit pkgs; };
-  gi-gtk-declarative = (import ./gi-gtk-declarative { inherit compiler doBenchmark doCheck; }).gi-gtk-declarative;
-  gi-gtk-declarative-app-simple = (import ./gi-gtk-declarative-app-simple { inherit compiler doBenchmark gi-gtk-declarative; }).gi-gtk-declarative-app-simple;
-  examples = (import ./examples { inherit compiler doBenchmark gi-gtk-declarative gi-gtk-declarative-app-simple; }).examples;
+  gi-gtk-declarative = (import ./gi-gtk-declarative { inherit compiler doBenchmark doCheck pkgs; }).gi-gtk-declarative;
+  gi-gtk-declarative-app-simple = (import ./gi-gtk-declarative-app-simple { inherit compiler doBenchmark gi-gtk-declarative pkgs; }).gi-gtk-declarative-app-simple;
+  examples = (import ./examples { inherit compiler doBenchmark gi-gtk-declarative gi-gtk-declarative-app-simple pkgs; }).examples;
 }

--- a/docs/requirements.nix
+++ b/docs/requirements.nix
@@ -5,7 +5,7 @@
 #   pypi2nix -V python37 -r requirements.txt
 #
 
-{ pkgs ? import <nixpkgs> {},
+{ pkgs ? import ../nixpkgs.nix,
   overrides ? ({ pkgs, python }: self: super: {})
 }:
 

--- a/examples/default.nix
+++ b/examples/default.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import <nixpkgs> {}, compiler ? "ghc862", doBenchmark ? false
+{ pkgs ? import ../nixpkgs.nix, compiler ? "ghc883", doBenchmark ? false
 , gi-gtk-declarative, gi-gtk-declarative-app-simple
 }:
 

--- a/gi-gtk-declarative-app-simple/default.nix
+++ b/gi-gtk-declarative-app-simple/default.nix
@@ -5,7 +5,6 @@
 let
   haskellPackages = pkgs.haskell.packages.${compiler}.override {
     overrides = self: super: {
-      haskell-gi-overloading = pkgs.haskell.lib.dontHaddock (self.callHackage "haskell-gi-overloading" "1.0" {});
       gi-gtk-declarative = gi-gtk-declarative;
     };
   };

--- a/gi-gtk-declarative-app-simple/default.nix
+++ b/gi-gtk-declarative-app-simple/default.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import <nixpkgs> {}, compiler ? "ghc862", doBenchmark ? false
+{ pkgs ? import ../nixpkgs.nix, compiler ? "ghc883", doBenchmark ? false
 , gi-gtk-declarative
 }:
 

--- a/gi-gtk-declarative/default.nix
+++ b/gi-gtk-declarative/default.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import <nixpkgs> {}, compiler ? "ghc865"
+{ pkgs ? import ./nixpkgs.nix, compiler ? "ghc883"
 , doCheck ? false, doBenchmark ? false
 }:
 

--- a/gi-gtk-declarative/default.nix
+++ b/gi-gtk-declarative/default.nix
@@ -1,10 +1,9 @@
-{ pkgs ? import ./nixpkgs.nix, compiler ? "ghc883"
+{ pkgs ? import ../nixpkgs.nix, compiler ? "ghc883"
 , doCheck ? false, doBenchmark ? false
 }:
 
 let
   haskellPackages = pkgs.haskell.packages.${compiler};
-
   applyCheck = if doCheck then pkgs.lib.id else pkgs.haskell.lib.dontCheck;
   applyBench = if doBenchmark then pkgs.haskell.lib.doBenchmark else pkgs.lib.id;
   drv =

--- a/gi-gtk-declarative/default.nix
+++ b/gi-gtk-declarative/default.nix
@@ -3,13 +3,8 @@
 }:
 
 let
-  haskellPackages = pkgs.haskell.packages.${compiler}.override {
-    overrides = self: super: {
-      criterion = self.callHackage "criterion" "1.5.3.0" {};
-      hedgehog = self.callHackage "hedgehog" "1.0" {};
-      haskell-gi-overloading = pkgs.haskell.lib.dontHaddock (self.callHackage "haskell-gi-overloading" "1.0" {});
-    };
-  };
+  haskellPackages = pkgs.haskell.packages.${compiler};
+
   applyCheck = if doCheck then pkgs.lib.id else pkgs.haskell.lib.dontCheck;
   applyBench = if doBenchmark then pkgs.haskell.lib.doBenchmark else pkgs.lib.id;
   drv =

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,0 +1,5 @@
+import (fetchTarball {
+  name = "nixpkgs-unstable-2020-04-05";
+  url = "https://github.com/nixos/nixpkgs/archive/05f0934825c2a0750d4888c4735f9420c906b388.tar.gz";
+  sha256 = "1g8c2w0661qn89ajp44znmwfmghbbiygvdzq0rzlvlpdiz28v6gy";
+}) {}

--- a/shell.nix
+++ b/shell.nix
@@ -1,10 +1,10 @@
-{ pkgs ? import <nixpkgs> {}, compiler ? "ghc865", doBenchmark ? true, doCheck ? true }:
+{ pkgs ? import ./nixpkgs.nix, compiler ? "ghc883", doBenchmark ? true, doCheck ? true }:
 let
   fontsConf = pkgs.makeFontsConf {
     fontDirectories = [ pkgs.cantarell-fonts ];
   };
   haskellPackages = pkgs.haskell.packages.${compiler};
-  project = import ./. { inherit compiler doBenchmark doCheck; };
+  project = import ./. { inherit compiler doBenchmark doCheck pkgs; };
 in
   haskellPackages.shellFor {
     withHoogle = true;

--- a/shell.nix
+++ b/shell.nix
@@ -16,6 +16,7 @@ in
     buildInputs = [
       project.docs.packages.mkdocs
       project.docs.packages.mkdocs-material
+      pkgs.cabal-install
     ];
     FONTCONFIG_FILE = fontsConf;
   }


### PR DESCRIPTION
This PR improves nix in a few ways:

- nixpkgs version is pinned by default, meaning that it is now fully reproducible and does not depend on the current clone of nixpkgs available on the system.
- `cabal-install` now comes as part of the main `nix-shell`, no need to install it separatly.
- a few override have been cleaned, resulting in a build which fetch all its dependencies from the nixpkgs binary cache. This should improves the build time on travis without even relying on cachix.