### PR TITLE
Relax version bounds of dependencies

### DIFF
--- a/gi-gtk-declarative-app-simple/gi-gtk-declarative-app-simple.cabal
+++ b/gi-gtk-declarative-app-simple/gi-gtk-declarative-app-simple.cabal
@@ -27,8 +27,8 @@ library
                       , gi-glib
                       , gi-gtk                  >= 3      && <4
                       , gi-gdk
-                      , haskell-gi              >= 0.21   && <0.24
-                      , haskell-gi-base         >= 0.21   && <0.24
+                      , haskell-gi              >= 0.21   && <0.25
+                      , haskell-gi-base         >= 0.21   && <0.25
                       , haskell-gi-overloading  == 1.0
                       , pipes                   >= 4      && <5
                       , pipes-concurrency       >= 2      && <3

--- a/gi-gtk-declarative/gi-gtk-declarative.cabal
+++ b/gi-gtk-declarative/gi-gtk-declarative.cabal
@@ -58,8 +58,8 @@ library
                       , gi-gobject             >= 2    && <3
                       , gi-glib                >= 2    && <3
                       , gi-gtk                 >= 3    && <4
-                      , haskell-gi             >= 0.21 && <0.24
-                      , haskell-gi-base        >= 0.21 && <0.24
+                      , haskell-gi             >= 0.21 && <0.25
+                      , haskell-gi-base        >= 0.21 && <0.25
                       , haskell-gi-overloading == 1.0
                       , mtl
                       , text


### PR DESCRIPTION
Hi,

Trying to `cabal build all` with GHC 8.8.4 (and 8.6.5 IIRC) I hit this error:

`cabal: Failed to build gi-pango-1.0.22`

With the relaxed upper bounds in gi-gtk-declarative*/*.cabal introduced by this PR, everything built fine. No complaints by `cabal test all` either.

If you accept this PR, do you think you could also add these changes as metadata revisions to Hackage (unless you create a new release anyway) so building this module directly from Hackage will work, too?

Thanks,
Martin