### PR TITLE
Bump dependencies

### DIFF
--- a/gi-gtk-declarative-app-simple/gi-gtk-declarative-app-simple.cabal
+++ b/gi-gtk-declarative-app-simple/gi-gtk-declarative-app-simple.cabal
@@ -27,8 +27,8 @@ library
                       , gi-glib
                       , gi-gtk                  >=3    && <4
                       , gi-gdk
-                      , haskell-gi              >=0.24 && <0.25
-                      , haskell-gi-base         >=0.24 && <0.25
+                      , haskell-gi              >=0.24 && <0.26
+                      , haskell-gi-base         >=0.24 && <0.26
                       , haskell-gi-overloading  >=1.0  && <1.1
                       , pipes                   >=4    && <5
                       , pipes-concurrency       >=2    && <3

--- a/gi-gtk-declarative/gi-gtk-declarative.cabal
+++ b/gi-gtk-declarative/gi-gtk-declarative.cabal
@@ -58,8 +58,8 @@ library
                       , gi-gobject             >=2    && <3
                       , gi-glib                >=2    && <3
                       , gi-gtk                 >=3    && <4
-                      , haskell-gi             >=0.24 && <0.25
-                      , haskell-gi-base        >=0.24 && <0.25
+                      , haskell-gi             >=0.24 && <0.26
+                      , haskell-gi-base        >=0.24 && <0.26
                       , haskell-gi-overloading >=1.0  && <1.1
                       , mtl
                       , text


### PR DESCRIPTION
Hi,

Without these bumps I encounter the following errors when trying to build:

* Failed to build gi-gdkpixbuf-2.0.24 (GHC 8.10.5)
* Failed to build haskell-gi-0.24.7 (GHC 9.0.1)

Cheers,
Martin