### PR TITLE
Support GHC 9.2.2 & updated bounds for haskell-gi 0.27

### DIFF
--- a/gi-gtk-declarative-app-simple/gi-gtk-declarative-app-simple.cabal
+++ b/gi-gtk-declarative-app-simple/gi-gtk-declarative-app-simple.cabal
@@ -27,8 +27,8 @@ library
                       , gi-glib
                       , gi-gtk                  >=3    && <4
                       , gi-gdk
-                      , haskell-gi              >=0.24 && <0.26
-                      , haskell-gi-base         >=0.24 && <0.26
+                      , haskell-gi              >=0.24 && <0.27
+                      , haskell-gi-base         >=0.24 && <0.27
                       , haskell-gi-overloading  >=1.0  && <1.1
                       , pipes                   >=4    && <5
                       , pipes-concurrency       >=2    && <3

--- a/gi-gtk-declarative/gi-gtk-declarative.cabal
+++ b/gi-gtk-declarative/gi-gtk-declarative.cabal
@@ -1,5 +1,5 @@
 name:                 gi-gtk-declarative
-version:              0.7.0
+version:              0.7.2
 synopsis:             Declarative GTK+ programming in Haskell
 description:          A declarative programming model for GTK+ user
                       interfaces, implementing support for various widgets
@@ -58,8 +58,8 @@ library
                       , gi-gobject             >=2    && <3
                       , gi-glib                >=2    && <3
                       , gi-gtk                 >=3    && <4
-                      , haskell-gi             >=0.24 && <0.26
-                      , haskell-gi-base        >=0.24 && <0.26
+                      , haskell-gi             >=0.24 && <0.27
+                      , haskell-gi-base        >=0.24 && <0.27
                       , haskell-gi-overloading >=1.0  && <1.1
                       , mtl
                       , text

--- a/gi-gtk-declarative/src/GI/Gtk/Declarative/Widget/Conversions.hs
+++ b/gi-gtk-declarative/src/GI/Gtk/Declarative/Widget/Conversions.hs
@@ -1,6 +1,7 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE UndecidableInstances  #-}
 

--- a/hie.yaml
+++ b/hie.yaml
@@ -1,6 +1,8 @@
 cradle:
-  direct:
-    arguments:
-      - -igi-gtk-declarative/src
-      - -igi-gtk-declarative-app-simple/src
-      - -iexamples
+  cabal:
+    - path: "./gi-gtk-declarative/src"
+      component: "lib:gi-gtk-declarative"
+    - path: "./gi-gtk-declarative-app-simple/src"
+      component: "lib:gi-gtk-declarative-app-simple"
+    - path: "./examples"
+      component: exe:example


### PR DESCRIPTION
Added 'FlexibleContexts' in Conversions.hs to support GHC 9.2.2.
It doesn't seem to have issues running on Linux, example programs also work well.

I changed hie.yaml to use cabal instead of direct, since direct does not work for me.
Can revert it back if it would be problematic.