### PR TITLE
App.Simple: Close App window before exiting

### DIFF
--- a/gi-gtk-declarative-app-simple/src/GI/Gtk/Declarative/App/Simple.hs
+++ b/gi-gtk-declarative-app-simple/src/GI/Gtk/Declarative/App/Simple.hs
@@ -156,7 +156,9 @@ runLoop App {..} = do
         Async.link a
 
         loop newState newMarkup events sub newModel
-      Exit -> return oldModel
+      Exit -> do
+        runUI $ Gtk.widgetDestroy =<< someStateWidget oldState
+        return oldModel
 
 -- | Assert that the program was linked using the @-threaded@ flag, to
 -- enable the threaded runtime required by this module.


### PR DESCRIPTION
Gtk doesn't destroy its windows when `gtk_main_exit()` is called. It relies on the X server to DestroyAll resources when the app's connection to the X server is closed.

This can result in zombie windows for programs which don't immediately exit after the Gtk main loop finishes.

We solve it by explicitly destroying the window widget in response to the `Exit` transition.

Also, for gtk_widget_destroy() to have any effect, the Gtk main loop needs to be still running. Thankfully, the `run` function provided by `GI.Gtk.Declarative.App.Simple` will ensure that is the case.

Resolves #105