### PR TITLE
cabal: Allow building with haskell-gi 0.26

### DIFF
--- a/gi-gtk-declarative-app-simple/gi-gtk-declarative-app-simple.cabal
+++ b/gi-gtk-declarative-app-simple/gi-gtk-declarative-app-simple.cabal
@@ -27,8 +27,8 @@ library
                       , gi-glib
                       , gi-gtk                  >=3    && <4
                       , gi-gdk
-                      , haskell-gi              >=0.24 && <0.26
-                      , haskell-gi-base         >=0.24 && <0.26
+                      , haskell-gi              >=0.24 && <0.27
+                      , haskell-gi-base         >=0.24 && <0.27
                       , haskell-gi-overloading  >=1.0  && <1.1
                       , pipes                   >=4    && <5
                       , pipes-concurrency       >=2    && <3

--- a/gi-gtk-declarative/gi-gtk-declarative.cabal
+++ b/gi-gtk-declarative/gi-gtk-declarative.cabal
@@ -58,8 +58,8 @@ library
                       , gi-gobject             >=2    && <3
                       , gi-glib                >=2    && <3
                       , gi-gtk                 >=3    && <4
-                      , haskell-gi             >=0.24 && <0.26
-                      , haskell-gi-base        >=0.24 && <0.26
+                      , haskell-gi             >=0.24 && <0.27
+                      , haskell-gi-base        >=0.24 && <0.27
                       , haskell-gi-overloading >=1.0  && <1.1
                       , mtl
                       , text

--- a/gi-gtk-declarative/src/GI/Gtk/Declarative/Widget/Conversions.hs
+++ b/gi-gtk-declarative/src/GI/Gtk/Declarative/Widget/Conversions.hs
@@ -1,6 +1,7 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE UndecidableInstances  #-}
 


### PR DESCRIPTION
This is a subset of PR #108 - just enough to allow gi-gtk-declarative-app-simple to be included in Stackage LTS and nixpkgs (see NixOS/nixpkgs#342755).

Resolves issue #100
